### PR TITLE
Reduce degradatations experiments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pion/interceptor
+module github.com/narayanaraorao/interceptor
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/narayanaraorao/interceptor
+module github.com/pion/interceptor
 
 go 1.15
 

--- a/internal/cc/feedback_adapter.go
+++ b/internal/cc/feedback_adapter.go
@@ -37,7 +37,7 @@ type FeedbackAdapter struct {
 // NewFeedbackAdapter returns a new FeedbackAdapter
 func NewFeedbackAdapter() *FeedbackAdapter {
 	return &FeedbackAdapter{
-		history: newFeedbackHistory(250),
+		history: newFeedbackHistory(1000),
 		log:     logging.NewDefaultLoggerFactory().NewLogger("feedback_adapter"),
 	}
 }

--- a/internal/cc/feedback_adapter.go
+++ b/internal/cc/feedback_adapter.go
@@ -37,7 +37,7 @@ type FeedbackAdapter struct {
 // NewFeedbackAdapter returns a new FeedbackAdapter
 func NewFeedbackAdapter() *FeedbackAdapter {
 	return &FeedbackAdapter{
-		history: newFeedbackHistory(1000),
+		history: newFeedbackHistory(25000),
 		log:     logging.NewDefaultLoggerFactory().NewLogger("feedback_adapter"),
 	}
 }

--- a/internal/cc/feedback_adapter.go
+++ b/internal/cc/feedback_adapter.go
@@ -37,7 +37,7 @@ type FeedbackAdapter struct {
 // NewFeedbackAdapter returns a new FeedbackAdapter
 func NewFeedbackAdapter() *FeedbackAdapter {
 	return &FeedbackAdapter{
-		history: newFeedbackHistory(25000),
+		history: newFeedbackHistory(250),
 		log:     logging.NewDefaultLoggerFactory().NewLogger("feedback_adapter"),
 	}
 }

--- a/pkg/gcc/adaptive_threshold.go
+++ b/pkg/gcc/adaptive_threshold.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	maxDeltas = 60
+	maxDeltas = 10
 )
 
 type adaptiveThresholdOption func(*adaptiveThreshold)
@@ -66,8 +66,8 @@ func (a *adaptiveThreshold) compare(estimate, _ time.Duration) (usage, time.Dura
 		return usageNormal, estimate, a.max
 	}
 	// this numDeltas is not there in the original paper, removing this as an experiment
-	//t := time.Duration(minInt(a.numDeltas, maxDeltas)) * estimate
-	t := estimate
+	t := time.Duration(minInt(a.numDeltas, maxDeltas)) * estimate
+	//t := estimate
 	use := usageNormal
 	if t > a.thresh {
 		use = usageOver

--- a/pkg/gcc/adaptive_threshold.go
+++ b/pkg/gcc/adaptive_threshold.go
@@ -65,6 +65,7 @@ func (a *adaptiveThreshold) compare(estimate, _ time.Duration) (usage, time.Dura
 	if a.numDeltas < 2 {
 		return usageNormal, estimate, a.max
 	}
+	// this numDeltas is not there in the original paper, removing this as an experiment
 	//t := time.Duration(minInt(a.numDeltas, maxDeltas)) * estimate
 	t := estimate
 	use := usageNormal

--- a/pkg/gcc/adaptive_threshold.go
+++ b/pkg/gcc/adaptive_threshold.go
@@ -65,7 +65,8 @@ func (a *adaptiveThreshold) compare(estimate, _ time.Duration) (usage, time.Dura
 	if a.numDeltas < 2 {
 		return usageNormal, estimate, a.max
 	}
-	t := time.Duration(minInt(a.numDeltas, maxDeltas)) * estimate
+	//t := time.Duration(minInt(a.numDeltas, maxDeltas)) * estimate
+	t := estimate
 	use := usageNormal
 	if t > a.thresh {
 		use = usageOver

--- a/pkg/gcc/adaptive_threshold.go
+++ b/pkg/gcc/adaptive_threshold.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	maxDeltas = 10
+	maxDeltas = 20
 )
 
 type adaptiveThresholdOption func(*adaptiveThreshold)

--- a/pkg/gcc/arrival_group.go
+++ b/pkg/gcc/arrival_group.go
@@ -11,15 +11,25 @@ import (
 )
 
 type arrivalGroup struct {
-	packets   []cc.Acknowledgment
-	departure time.Time
-	arrival   time.Time
+	packets        []cc.Acknowledgment
+	departure      time.Time
+	arrival        time.Time
+	firstDeparture time.Time
 }
 
 func (g *arrivalGroup) add(a cc.Acknowledgment) {
+	if len(g.packets) == 0 {
+		g.firstDeparture = a.Departure
+	}
 	g.packets = append(g.packets, a)
 	g.arrival = a.Arrival
-	g.departure = a.Departure
+	if a.Departure.After(g.departure) {
+		g.departure = a.Departure
+	}
+	if a.Departure.Before(g.firstDeparture) {
+		g.firstDeparture = a.Departure
+	}
+
 }
 
 func (g arrivalGroup) String() string {

--- a/pkg/gcc/arrival_group.go
+++ b/pkg/gcc/arrival_group.go
@@ -11,9 +11,11 @@ import (
 )
 
 type arrivalGroup struct {
-	packets        []cc.Acknowledgment
-	departure      time.Time
-	arrival        time.Time
+	packets []cc.Acknowledgment
+	// departure holds the highest departure timestamp till now
+	departure time.Time
+	arrival   time.Time
+	// firstDeparture holds the lowest departure timestamp till now
 	firstDeparture time.Time
 }
 
@@ -23,6 +25,7 @@ func (g *arrivalGroup) add(a cc.Acknowledgment) {
 	}
 	g.packets = append(g.packets, a)
 	g.arrival = a.Arrival
+
 	if a.Departure.After(g.departure) {
 		g.departure = a.Departure
 	}

--- a/pkg/gcc/arrival_group_accumulator.go
+++ b/pkg/gcc/arrival_group_accumulator.go
@@ -4,7 +4,6 @@
 package gcc
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/pion/interceptor/internal/cc"
@@ -50,9 +49,9 @@ func (a *arrivalGroupAccumulator) run(in <-chan []cc.Acknowledgment, agWriter fu
 					continue
 				}
 
-				fmt.Println("different group, dep delay:", interDepartureTimePkt(group, next),
-					", interArrivalTimePkt:", interArrivalTimePkt(group, next),
-					",interGroupDelayVariationPkt:", interGroupDelayVariationPkt(group, next))
+				// fmt.Println("different group, dep delay:", interDepartureTimePkt(group, next),
+				// 	", interArrivalTimePkt:", interArrivalTimePkt(group, next),
+				// 	",interGroupDelayVariationPkt:", interGroupDelayVariationPkt(group, next))
 				agWriter(group)
 				group = arrivalGroup{}
 				group.add(next)
@@ -65,6 +64,8 @@ func interArrivalTimePkt(a arrivalGroup, b cc.Acknowledgment) time.Duration {
 	return b.Arrival.Sub(a.arrival)
 }
 
+// libwebrtc takes a difference between first departure and last departure
+// pion was looking at the difference between penultimate and last departures
 func interDepartureTimePkt(a arrivalGroup, b cc.Acknowledgment) time.Duration {
 	if len(a.packets) == 0 {
 		return 0

--- a/pkg/gcc/arrival_group_accumulator.go
+++ b/pkg/gcc/arrival_group_accumulator.go
@@ -17,7 +17,11 @@ type arrivalGroupAccumulator struct {
 
 func newArrivalGroupAccumulator() *arrivalGroupAccumulator {
 	return &arrivalGroupAccumulator{
-		interDepartureThreshold:          100 * time.Microsecond, //Narayan: this is 0 in libwebrtc
+		// interDepartureThreshold is 0 in lib webrtc C++ code
+		// TimeDelta send_time_delta = send_time - current_timestamp_group_.send_time;
+		// if (send_time_delta.IsZero())
+		// return true;
+		interDepartureThreshold:          100 * time.Microsecond,
 		interArrivalThreshold:            5 * time.Millisecond,
 		interGroupDelayVariationTreshold: 0,
 	}

--- a/pkg/gcc/arrival_group_accumulator.go
+++ b/pkg/gcc/arrival_group_accumulator.go
@@ -17,7 +17,7 @@ type arrivalGroupAccumulator struct {
 
 func newArrivalGroupAccumulator() *arrivalGroupAccumulator {
 	return &arrivalGroupAccumulator{
-		interDepartureThreshold:          5 * time.Millisecond,
+		interDepartureThreshold:          100 * time.Microsecond, //Narayan: this is 0 in libwebrtc
 		interArrivalThreshold:            5 * time.Millisecond,
 		interGroupDelayVariationTreshold: 0,
 	}

--- a/pkg/gcc/kalman.go
+++ b/pkg/gcc/kalman.go
@@ -4,7 +4,6 @@
 package gcc
 
 import (
-	"fmt"
 	"math"
 	"time"
 )
@@ -107,7 +106,7 @@ func (k *kalman) updateEstimate(measurement time.Duration) time.Duration {
 	k.estimate += time.Duration(k.gain * zms * float64(time.Millisecond))
 
 	k.estimateError = (1 - k.gain) * estimateUncertainty
-	fmt.Println("k.measurementUncertainty:", k.measurementUncertainty, ",k.gain:", k.gain,
-		",estimateUncertainty", estimateUncertainty, ",k.estimateError", k.estimateError, ",k.estimate:", k.estimate)
+	// fmt.Println("k.measurementUncertainty:", k.measurementUncertainty, ",k.gain:", k.gain,
+	// 	",estimateUncertainty", estimateUncertainty, ",k.estimateError", k.estimateError, ",k.estimate:", k.estimate)
 	return k.estimate
 }

--- a/pkg/gcc/kalman.go
+++ b/pkg/gcc/kalman.go
@@ -4,6 +4,7 @@
 package gcc
 
 import (
+	"fmt"
 	"math"
 	"time"
 )
@@ -106,5 +107,7 @@ func (k *kalman) updateEstimate(measurement time.Duration) time.Duration {
 	k.estimate += time.Duration(k.gain * zms * float64(time.Millisecond))
 
 	k.estimateError = (1 - k.gain) * estimateUncertainty
+	fmt.Println("k.measurementUncertainty:", k.measurementUncertainty, ",k.gain:", k.gain,
+		",estimateUncertainty", estimateUncertainty, ",k.estimateError", k.estimateError, ",k.estimate:", k.estimate)
 	return k.estimate
 }

--- a/pkg/gcc/kalman.go
+++ b/pkg/gcc/kalman.go
@@ -15,12 +15,12 @@ const (
 type kalmanOption func(*kalman)
 
 type kalman struct {
-	gain                   float64
-	estimate               time.Duration
-	processUncertainty     float64 // Q_i
-	estimateError          float64
-	measurementUncertainty float64
-
+	gain                                 float64
+	estimate                             time.Duration
+	processUncertainty                   float64 // Q_i
+	estimateError                        float64
+	measurementUncertainty               float64
+	lastUpdate                           time.Time
 	disableMeasurementUncertaintyUpdates bool
 }
 
@@ -62,6 +62,7 @@ func newKalman(opts ...kalmanOption) *kalman {
 		estimateError:                        0.1,
 		measurementUncertainty:               0,
 		disableMeasurementUncertaintyUpdates: false,
+		lastUpdate:                           time.Time{},
 	}
 	for _, opt := range opts {
 		opt(k)
@@ -70,6 +71,21 @@ func newKalman(opts ...kalmanOption) *kalman {
 }
 
 func (k *kalman) updateEstimate(measurement time.Duration) time.Duration {
+	now := time.Now()
+	if k.lastUpdate.IsZero() {
+		k.lastUpdate = now
+	}
+	// if there is a large gap, reset the state and ignore the first twcc feedback
+	if now.Sub(k.lastUpdate).Milliseconds() > 5000 {
+		k.measurementUncertainty = 0
+		k.estimate = 0
+		k.estimateError = 0.1
+		k.gain = 0
+		k.processUncertainty = 1e-3
+		k.lastUpdate = now
+		return k.estimate
+	}
+	k.lastUpdate = now
 	z := measurement - k.estimate
 
 	zms := float64(z.Microseconds()) / 1000.0

--- a/pkg/gcc/overuse_detector.go
+++ b/pkg/gcc/overuse_detector.go
@@ -4,8 +4,9 @@
 package gcc
 
 import (
-	"github.com/pion/logging"
 	"time"
+
+	"github.com/pion/logging"
 )
 
 type threshold interface {
@@ -59,7 +60,7 @@ func (d *overuseDetector) onDelayStats(ds DelayStats) {
 			d.increasingDuration += delta
 		}
 		d.increasingCounter++
-		if d.increasingDuration > d.overuseTime && d.increasingCounter > 1 {
+		if d.increasingDuration > d.overuseTime && d.increasingCounter > 3 {
 			if estimate > d.lastEstimate {
 				use = usageOver
 			}

--- a/pkg/gcc/overuse_detector.go
+++ b/pkg/gcc/overuse_detector.go
@@ -60,7 +60,7 @@ func (d *overuseDetector) onDelayStats(ds DelayStats) {
 			d.increasingDuration += delta
 		}
 		d.increasingCounter++
-		if d.increasingDuration > d.overuseTime && d.increasingCounter > 3 {
+		if d.increasingDuration > d.overuseTime && d.increasingCounter > 1 {
 			if estimate > d.lastEstimate {
 				d.increasingCounter = 0
 				d.increasingDuration = 0

--- a/pkg/gcc/overuse_detector.go
+++ b/pkg/gcc/overuse_detector.go
@@ -62,6 +62,8 @@ func (d *overuseDetector) onDelayStats(ds DelayStats) {
 		d.increasingCounter++
 		if d.increasingDuration > d.overuseTime && d.increasingCounter > 3 {
 			if estimate > d.lastEstimate {
+				d.increasingCounter = 0
+				d.increasingDuration = 0
 				use = usageOver
 			}
 		}

--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -4,6 +4,7 @@
 package gcc
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -91,7 +92,7 @@ func (c *rateController) onDelayStats(ds DelayStats) {
 	}
 	c.delayStats = ds
 	c.delayStats.State = c.delayStats.State.transition(ds.Usage)
-
+	fmt.Println("delay stats:", ds, ",state:", c.delayStats.State)
 	if c.delayStats.State == stateHold {
 		return
 	}

--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -154,7 +154,9 @@ func (c *rateController) increase(now time.Time) int {
 
 	// maximum increase to 1.5 * received rate
 	received := int(1.5 * float64(c.latestReceivedRate))
-	if rate > received && received > c.target {
+	//if rate > received && received > c.target {
+	// Narayan: We should not go above 1.5x in any case
+	if rate > received {
 		return received
 	}
 

--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -4,7 +4,6 @@
 package gcc
 
 import (
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -92,7 +91,7 @@ func (c *rateController) onDelayStats(ds DelayStats) {
 	}
 	c.delayStats = ds
 	c.delayStats.State = c.delayStats.State.transition(ds.Usage)
-	fmt.Println("delay stats:", ds, ",state:", c.delayStats.State)
+	//fmt.Println("delay stats:", ds, ",state:", c.delayStats.State)
 	if c.delayStats.State == stateHold {
 		return
 	}

--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -154,9 +154,7 @@ func (c *rateController) increase(now time.Time) int {
 
 	// maximum increase to 1.5 * received rate
 	received := int(1.5 * float64(c.latestReceivedRate))
-	//if rate > received && received > c.target {
-	// Narayan: We should not go above 1.5x in any case
-	if rate > received {
+	if rate > received && received > c.target {
 		return received
 	}
 

--- a/pkg/gcc/rate_controller.go
+++ b/pkg/gcc/rate_controller.go
@@ -4,6 +4,7 @@
 package gcc
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -91,7 +92,7 @@ func (c *rateController) onDelayStats(ds DelayStats) {
 	}
 	c.delayStats = ds
 	c.delayStats.State = c.delayStats.State.transition(ds.Usage)
-	//fmt.Println("delay stats:", ds, ",state:", c.delayStats.State)
+	fmt.Println("delay stats:", ds, ",state:", c.delayStats.State)
 	if c.delayStats.State == stateHold {
 		return
 	}

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -5,6 +5,7 @@ package gcc
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"sync"
 	"time"

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -55,8 +55,9 @@ type SendSideBWE struct {
 	minBitrate    int
 	maxBitrate    int
 
-	close     chan struct{}
-	closeLock sync.RWMutex
+	close      chan struct{}
+	closeLock  sync.RWMutex
+	lastUpdate time.Time
 }
 
 // Option configures a bandwidth estimator
@@ -268,16 +269,22 @@ func (e *SendSideBWE) onDelayUpdate(delayStats DelayStats) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
+	now := time.Now()
+	if e.lastUpdate.IsZero() {
+		e.lastUpdate = now
+	}
+
 	lossStats := e.lossController.getEstimate(delayStats.TargetBitrate)
 	bitrateChanged := false
 	//fmt.Println("delaybitrate:", delayStats.TargetBitrate, ",lossbitrate:", lossStats.TargetBitrate)
 	bitrate := minInt(delayStats.TargetBitrate, lossStats.TargetBitrate)
-	if bitrate != e.latestBitrate {
+	// Even if the bitrate has not changed, send the update, since our algorithm depends on constant updates
+	if bitrate != e.latestBitrate || now.Sub(e.lastUpdate).Milliseconds() > 500 {
 		bitrateChanged = true
 		e.latestBitrate = bitrate
 		e.pacer.SetTargetBitrate(e.latestBitrate)
+		e.lastUpdate = now
 	}
-
 	if bitrateChanged && e.onTargetBitrateChange != nil {
 		go e.onTargetBitrateChange(bitrate)
 	}

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -270,6 +270,7 @@ func (e *SendSideBWE) onDelayUpdate(delayStats DelayStats) {
 
 	lossStats := e.lossController.getEstimate(delayStats.TargetBitrate)
 	bitrateChanged := false
+	fmt.Println("delaybitrate:", delayStats.TargetBitrate, ",lossbitrate:", lossStats.TargetBitrate)
 	bitrate := minInt(delayStats.TargetBitrate, lossStats.TargetBitrate)
 	if bitrate != e.latestBitrate {
 		bitrateChanged = true

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -203,6 +203,7 @@ func (e *SendSideBWE) WriteRTCP(pkts []rtcp.Packet, _ interceptor.Attributes) er
 		}
 		if feedbackMinRTT < math.MaxInt {
 			e.delayController.updateRTT(feedbackMinRTT)
+			e.lossController.updateRTT(feedbackMinRTT)
 		}
 
 		e.lossController.updateLossEstimate(acks)

--- a/pkg/gcc/send_side_bwe.go
+++ b/pkg/gcc/send_side_bwe.go
@@ -5,7 +5,6 @@ package gcc
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -271,7 +270,7 @@ func (e *SendSideBWE) onDelayUpdate(delayStats DelayStats) {
 
 	lossStats := e.lossController.getEstimate(delayStats.TargetBitrate)
 	bitrateChanged := false
-	fmt.Println("delaybitrate:", delayStats.TargetBitrate, ",lossbitrate:", lossStats.TargetBitrate)
+	//fmt.Println("delaybitrate:", delayStats.TargetBitrate, ",lossbitrate:", lossStats.TargetBitrate)
 	bitrate := minInt(delayStats.TargetBitrate, lossStats.TargetBitrate)
 	if bitrate != e.latestBitrate {
 		bitrateChanged = true


### PR DESCRIPTION
Looked at libwebrtc and made 3 changes from earlier:
When checking for arrival group, we should look at diff between first packet's departure and last packet's departure. Pion was looking at diff between penultimate packet's departure and last packet's departure
When updating the adaptive threshold, we should look at time diff between packet arrivals and not system time diff. Since multiple acks come in same TWCC packet, system time diff between 2 threshold updates is often 0
Reverted my change in num_deltas from 60 to 20. We are not playing with constants anymore!